### PR TITLE
Feature - ActiveMQ Artemis Support

### DIFF
--- a/ExtensionType.php
+++ b/ExtensionType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enqueue\Stomp;
+
+class ExtensionType
+{
+    const ACTIVEMQ = 'activemq';
+    const RABBITMQ = 'rabbitmq';
+    const ARTEMIS = 'artemis';
+}

--- a/StompContext.php
+++ b/StompContext.php
@@ -24,6 +24,11 @@ class StompContext implements Context
     private $stomp;
 
     /**
+     * @var string
+     */
+    private $extensionType;
+
+    /**
      * @var bool
      */
     private $useExchangePrefix;
@@ -35,9 +40,9 @@ class StompContext implements Context
 
     /**
      * @param BufferedStompClient|callable $stomp
-     * @param bool                         $useExchangePrefix
+     * @param string                       $extensionType
      */
-    public function __construct($stomp, $useExchangePrefix = true)
+    public function __construct($stomp, string $extensionType)
     {
         if ($stomp instanceof BufferedStompClient) {
             $this->stomp = $stomp;
@@ -47,7 +52,8 @@ class StompContext implements Context
             throw new \InvalidArgumentException('The stomp argument must be either BufferedStompClient or callable that return BufferedStompClient.');
         }
 
-        $this->useExchangePrefix = $useExchangePrefix;
+        $this->extensionType = $extensionType;
+        $this->useExchangePrefix = true;
     }
 
     /**
@@ -64,7 +70,7 @@ class StompContext implements Context
     public function createQueue(string $name): Queue
     {
         if (0 !== strpos($name, '/')) {
-            $destination = new StompDestination();
+            $destination = new StompDestination($this->extensionType);
             $destination->setType(StompDestination::TYPE_QUEUE);
             $destination->setStompName($name);
 
@@ -91,7 +97,7 @@ class StompContext implements Context
     public function createTopic(string $name): Topic
     {
         if (0 !== strpos($name, '/')) {
-            $destination = new StompDestination();
+            $destination = new StompDestination($this->extensionType);
             $destination->setType($this->useExchangePrefix ? StompDestination::TYPE_EXCHANGE : StompDestination::TYPE_TOPIC);
             $destination->setStompName($name);
 
@@ -151,7 +157,7 @@ class StompContext implements Context
             $routingKey = $pieces[1];
         }
 
-        $destination = new StompDestination();
+        $destination = new StompDestination($this->extensionType);
         $destination->setType($type);
         $destination->setStompName($name);
         $destination->setRoutingKey($routingKey);

--- a/StompDestination.php
+++ b/StompDestination.php
@@ -39,14 +39,25 @@ class StompDestination implements Topic, Queue
      * @var array
      */
     private $headers;
+    /**
+     * @var string
+     */
+    private string $extensionType;
 
-    public function __construct()
+    public function __construct(string $extensionType)
     {
         $this->headers = [
             self::HEADER_DURABLE => false,
             self::HEADER_AUTO_DELETE => true,
             self::HEADER_EXCLUSIVE => false,
         ];
+
+        $this->extensionType = $extensionType;
+    }
+
+    public function getExtensionType(): string
+    {
+        return $this->extensionType;
     }
 
     public function getStompName(): string
@@ -63,6 +74,10 @@ class StompDestination implements Topic, Queue
     {
         if (empty($this->getStompName())) {
             throw new \LogicException('Destination name is not set');
+        }
+
+        if ($this->extensionType === ExtensionType::ARTEMIS) {
+            return $this->getStompName();
         }
 
         $name = '/'.$this->getType().'/'.$this->getStompName();


### PR DESCRIPTION
Hey @makasim! :wave: 

I've managed to put together a first draft for supporting ActiveMQ Artemis using the Enqueue STOMP driver. I have this working locally and I've done my best to stick to your code style, giving in to the odd improvement.

The biggest change I've made is to plumb the notion of broker extensions a bit further into the hierarchy of objects. I noticed in quite a few places, RabbitMQ preferences are hard-coded because there wasn't any way to check which set of extensions are desired for the connection.  I'll make further notes on the code in the PR to help you scan through things.

Let me know what you think and note any changes or improvements you're after.  I have not added tests as I am hoping to get help from you on that if it's something you want done.

_Closes: https://github.com/php-enqueue/enqueue-dev/issues/1067_